### PR TITLE
feat: add live dataset ingest monitoring

### DIFF
--- a/src/api/datasets.ts
+++ b/src/api/datasets.ts
@@ -1,0 +1,32 @@
+import { API_BASE_URL } from "@/lib/env";
+import { apiClient } from "@/lib/api";
+import type { Dataset, DatasetDetail } from "@/types/datasets";
+
+export async function listDatasets(): Promise<Dataset[]> {
+  return apiClient.get("api/v1/datasets").json<Dataset[]>();
+}
+
+export async function getDataset(id: string): Promise<DatasetDetail> {
+  return apiClient.get(`api/v1/datasets/${id}`).json<DatasetDetail>();
+}
+
+export async function deleteDataset(
+  id: string,
+  options: { force?: boolean } = {}
+): Promise<void> {
+  const searchParams = options.force ? new URLSearchParams({ force: "true" }) : undefined;
+  await apiClient.delete(`api/v1/datasets/${id}`, { searchParams });
+}
+
+export async function cancelIngest(id: string): Promise<void> {
+  await apiClient.post(`api/v1/datasets/${id}/cancel`);
+}
+
+export async function startIngest(id: string): Promise<void> {
+  await apiClient.post(`api/v1/datasets/${id}/ingest`);
+}
+
+export function ingestEvents(id: string): EventSource {
+  const url = `${API_BASE_URL}/api/v1/datasets/${id}/events`;
+  return new EventSource(url, { withCredentials: false });
+}

--- a/src/app/datasets/page.tsx
+++ b/src/app/datasets/page.tsx
@@ -1,99 +1,309 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { toast } from "sonner";
+
+import { listDatasets, deleteDataset as deleteDatasetApi, startIngest, cancelIngest as cancelIngestApi } from "@/api/datasets";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { DataTable, type DataTableColumn } from "@/components/DataTable";
+import { DatasetIngestDrawer } from "@/components/DatasetIngestDrawer";
+import { ComboBox } from "@/components/ComboBox";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select";
-import { ComboBox } from "@/components/ComboBox";
-
-import type { DatasetSummary, Interval } from "@/lib/api-types";
+import { useDatasetIngest } from "@/hooks/useDatasetIngest";
+import type { Dataset, DatasetStatus } from "@/types/datasets";
 import {
-  useCreateDataset, useDatasets, useIngestDataset,
-  useSymbols, useIntervals, useAvailableRange,
+  useCreateDataset,
+  useSymbols,
+  useIntervals,
+  useAvailableRange,
 } from "@/lib/hooks";
-import { formatDateTime } from "@/lib/time";
+import { formatRelativeTime } from "@/lib/time";
+
+import type { Interval } from "@/lib/api-types";
 
 const INTERVAL_VALUES: [Interval, ...Interval[]] = [
-  "1m","3m","5m","15m","30m",
-  "1h","2h","4h","6h","8h","12h",
-  "1d","3d","1w","1M",
+  "1m",
+  "3m",
+  "5m",
+  "15m",
+  "30m",
+  "1h",
+  "2h",
+  "4h",
+  "6h",
+  "8h",
+  "12h",
+  "1d",
+  "3d",
+  "1w",
+  "1M",
 ];
 
-const datasetSchema = z.object({
-  symbol: z.string().min(1, "Seleccioná un par"),
-  interval: z.enum(INTERVAL_VALUES),
-  startTime: z.coerce.number().int().min(0, "Fecha inválida"),
-  endTime: z.coerce.number().int().min(0, "Fecha inválida"),
-  name: z.string().min(1, "Nombre requerido"),
-}).refine(d => d.endTime > d.startTime, {
-  message: "El fin debe ser mayor al inicio",
-  path: ["endTime"],
-});
+const datasetSchema = z
+  .object({
+    symbol: z.string().min(1, "Seleccioná un par"),
+    interval: z.enum(INTERVAL_VALUES),
+    startTime: z.coerce.number().int().min(0, "Fecha inválida"),
+    endTime: z.coerce.number().int().min(0, "Fecha inválida"),
+    name: z.string().min(1, "Nombre requerido"),
+  })
+  .refine((d) => d.endTime > d.startTime, {
+    message: "El fin debe ser mayor al inicio",
+    path: ["endTime"],
+  });
+
+const FINAL_STATUSES: DatasetStatus[] = ["Ready", "Failed", "Canceled"];
+
+type DatasetRow = Dataset & { updatedAt?: number; progress?: number; lastMessage?: string };
 
 export default function DatasetsPage() {
+  const queryClient = useQueryClient();
   const [formState, setFormState] = useState<{
-    symbol: string; interval: Interval | ""; startLocal: string; endLocal: string;
+    symbol: string;
+    interval: Interval | "";
+    startLocal: string;
+    endLocal: string;
   }>({
-    symbol: "", interval: "", startLocal: "", endLocal: "",
+    symbol: "",
+    interval: "",
+    startLocal: "",
+    endLocal: "",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
-
-  const datasetsQuery = useDatasets();
-  const createDataset = useCreateDataset();
-  const ingestDataset = useIngestDataset();
-
-  // dropdowns on-demand (intervals sigue usando Select)
   const [intervalsOpen, setIntervalsOpen] = useState(false);
-  const symbolsQuery = useSymbols(true);        // cargamos de una para el ComboBox
-  const intervalsQuery = useIntervals(intervalsOpen);
+  const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null);
+  const [confirmState, setConfirmState] = useState<{
+    dataset: Dataset;
+    force?: boolean;
+  } | null>(null);
 
+  const datasetsQuery = useQuery({
+    queryKey: ["datasets"],
+    queryFn: listDatasets,
+  });
+
+  const createDataset = useCreateDataset();
+
+  const startIngestMutation = useMutation({
+    mutationFn: (id: string) => startIngest(id),
+    onSuccess: (_, id) => {
+      toast.success("Ingesta iniciada");
+      queryClient.invalidateQueries({ queryKey: ["datasets"] });
+      setSelectedDatasetId(id);
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "No se pudo iniciar la ingesta";
+      toast.error(message);
+    },
+  });
+
+  const cancelIngestMutation = useMutation({
+    mutationFn: (id: string) => cancelIngestApi(id),
+    onSuccess: () => {
+      toast.success("Ingesta cancelada");
+      queryClient.invalidateQueries({ queryKey: ["datasets"] });
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "No se pudo cancelar la ingesta";
+      toast.error(message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ id, force }: { id: string; force?: boolean }) =>
+      deleteDatasetApi(id, { force }),
+    onSuccess: (_, variables) => {
+      toast.success("Dataset eliminado");
+      queryClient.invalidateQueries({ queryKey: ["datasets"] });
+      setConfirmState(null);
+      if (variables.id === selectedDatasetId) {
+        setSelectedDatasetId(null);
+      }
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "No se pudo eliminar el dataset";
+      toast.error(message);
+    },
+  });
+
+  const symbolsQuery = useSymbols(true);
+  const intervalsQuery = useIntervals(intervalsOpen);
   const rangeQuery = useAvailableRange(formState.symbol, formState.interval);
 
-  // Helpers de conversión
   const toMs = (local: string) => (local ? new Date(local).getTime() : 0);
-  const fromMs = (ms: number) => new Date(ms).toISOString().slice(0,16); // yyyy-MM-ddTHH:mm
+  const fromMs = (ms: number) => new Date(ms).toISOString().slice(0, 16);
 
   const r = rangeQuery.data;
   const minLocal = r ? fromMs(r.firstOpenTime) : undefined;
   const maxLocal = r ? fromMs(r.lastCloseTime) : undefined;
 
-  const columns = useMemo<DataTableColumn<DatasetSummary>[]>(() => [
-    { key: "symbol", header: "Par" },
-    { key: "interval", header: "Intervalo" },
-    { key: "startTime", header: "Desde", render: (row) => formatDateTime(row.startTime) },
-    { key: "endTime", header: "Hasta", render: (row) => formatDateTime(row.endTime) },
-    { key: "status", header: "Estado" },
-    {
-      key: "actions",
-      header: "Acciones",
-      render: (row) => (
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={ingestDataset.isPending || row.status === "ingesting"}
-          onClick={async () => {
-            try {
-              await ingestDataset.mutateAsync(row.id);
-              toast.success(`Ingesta iniciada para ${row.symbol} ${row.interval}`);
-            } catch (error) {
-              const message =
-                error instanceof Error
-                  ? error.message
-                  : "No se pudo iniciar la ingesta";
-              toast.error(message);
-            }
-          }}
-        >
-          Ingestar
-        </Button>
-      ),
-    },
-  ], [ingestDataset]);
+  const datasets = datasetsQuery.data ?? [];
+  const activeDataset = selectedDatasetId
+    ? datasets.find((d) => d.id === selectedDatasetId) ?? null
+    : null;
+
+  const ingestState = useDatasetIngest(selectedDatasetId ?? "", {
+    enabled: Boolean(selectedDatasetId),
+  });
+
+  const triggerStartIngest = startIngestMutation.mutate;
+  const triggerCancelIngest = cancelIngestMutation.mutate;
+  const isStartingIngest = startIngestMutation.isPending;
+  const isCancelingIngest = cancelIngestMutation.isPending;
+  const isDeletingDataset = deleteMutation.isPending;
+
+  useEffect(() => {
+    if (!ingestState.data) return;
+    queryClient.setQueryData<Dataset[]>(["datasets"], (prev) => {
+      if (!prev) return prev;
+      return prev.map((dataset) =>
+        dataset.id === ingestState.data?.id
+          ? { ...dataset, ...ingestState.data }
+          : dataset
+      );
+    });
+  }, [ingestState.data, queryClient]);
+
+  const previousStatusRef = useRef<DatasetStatus | undefined>();
+  useEffect(() => {
+    const status = ingestState.data?.status;
+    if (!status) return;
+    const prev = previousStatusRef.current;
+    if (prev !== status && FINAL_STATUSES.includes(status)) {
+      datasetsQuery.refetch();
+    }
+    previousStatusRef.current = status;
+  }, [datasetsQuery, ingestState.data?.status]);
+
+  const columns = useMemo<DataTableColumn<DatasetRow>[]>(() => {
+    const renderStatus = (row: DatasetRow) => {
+      const status = row.status;
+      const variant =
+        status === "Ready"
+          ? "default"
+          : status === "Ingesting"
+          ? "secondary"
+          : "outline";
+      const statusClass =
+        status === "Failed"
+          ? "bg-destructive text-destructive-foreground border-destructive"
+          : status === "Ready"
+          ? "bg-emerald-100 text-emerald-900 border-emerald-200 dark:bg-emerald-500/20 dark:text-emerald-100"
+          : status === "Ingesting"
+          ? "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-500/20 dark:text-blue-100"
+          : status === "Canceled"
+          ? "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-500/20 dark:text-yellow-100"
+          : undefined;
+      return (
+        <Badge variant={variant} className={statusClass}>
+          {status}
+        </Badge>
+      );
+    };
+
+    return [
+      {
+        key: "name",
+        header: "Nombre",
+        render: (row) => row.name ?? `${row.symbol}-${row.interval}`,
+      },
+      { key: "symbol", header: "Par" },
+      { key: "interval", header: "Intervalo" },
+      {
+        key: "status",
+        header: "Estado",
+        render: renderStatus,
+      },
+      {
+        key: "progress",
+        header: "Progreso",
+        render: (row) => (
+          <div className="space-y-2">
+            <Progress value={row.progress ?? 0} />
+            <div className="text-xs text-muted-foreground">
+              {row.lastMessage
+                ? `${Math.round(row.progress ?? 0)}% • ${row.lastMessage}`
+                : `${Math.round(row.progress ?? 0)}%`}
+            </div>
+          </div>
+        ),
+      },
+      {
+        key: "updatedAt",
+        header: "Actualizado",
+        render: (row) => (row.updatedAt ? formatRelativeTime(row.updatedAt) : "-"),
+      },
+      {
+        key: "actions",
+        header: "Acciones",
+        render: (row) => {
+          const canIngest = ["Registered", "Failed", "Canceled"].includes(row.status);
+          const isIngesting = row.status === "Ingesting";
+          const isDeleting = isDeletingDataset && confirmState?.dataset.id === row.id;
+
+          return (
+            <div className="flex flex-wrap gap-2">
+              {canIngest ? (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={isStartingIngest}
+                  onClick={() => triggerStartIngest(row.id)}
+                >
+                  Ingestar
+                </Button>
+              ) : null}
+              {isIngesting ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={isCancelingIngest}
+                  onClick={() => triggerCancelIngest(row.id)}
+                >
+                  Cancelar
+                </Button>
+              ) : null}
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={isDeleting}
+                onClick={() =>
+                  setConfirmState({
+                    dataset: row,
+                    force: row.status === "Ingesting",
+                  })
+                }
+              >
+                {row.status === "Ingesting" ? "Force delete" : "Eliminar"}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setSelectedDatasetId(row.id)}>
+                Logs
+              </Button>
+            </div>
+          );
+        },
+      },
+    ];
+  }, [
+    confirmState,
+    isCancelingIngest,
+    isDeletingDataset,
+    isStartingIngest,
+    triggerCancelIngest,
+    triggerStartIngest,
+  ]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -104,53 +314,59 @@ export default function DatasetsPage() {
       endTime: toMs(formState.endLocal || maxLocal || ""),
       name: `${formState.symbol}-${formState.interval}`,
     };
-    const p = datasetSchema.safeParse(payload);
-    if (!p.success) {
-      const m: Record<string,string> = {};
-      p.error.issues.forEach(i => {
-        const k = (i.path[0] as string) || "form";
-        m[k] = i.message;
+    const parsed = datasetSchema.safeParse(payload);
+    if (!parsed.success) {
+      const validationErrors: Record<string, string> = {};
+      parsed.error.issues.forEach((issue) => {
+        const key = (issue.path[0] as string) || "form";
+        validationErrors[key] = issue.message;
       });
-      setErrors(m);
+      setErrors(validationErrors);
       return;
     }
     setErrors({});
     try {
-      await createDataset.mutateAsync(p.data);
+      await createDataset.mutateAsync(parsed.data);
       toast.success("Dataset creado");
-      setFormState({ symbol:"", interval: "", startLocal:"", endLocal:"" });
+      setFormState({ symbol: "", interval: "", startLocal: "", endLocal: "" });
+      queryClient.invalidateQueries({ queryKey: ["datasets"] });
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "No se pudo crear el dataset";
+      const message = error instanceof Error ? error.message : "No se pudo crear el dataset";
       toast.error(message);
     }
   };
+
+  const confirmDatasetDeletion = confirmState?.dataset;
 
   return (
     <div className="space-y-6">
       <header className="space-y-1">
         <h1 className="text-2xl font-semibold">Datasets</h1>
         <p className="text-sm text-muted-foreground">
-          Registrá datasets desde Binance y lanzá la ingesta desde la UI.
+          Registrá datasets desde Binance y seguí la ingesta en tiempo real.
         </p>
       </header>
 
-      <section className="grid gap-6 md:grid-cols-[2fr,1fr]">
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold">Listado</h2>
-            <Button size="sm" onClick={() => datasetsQuery.refetch()} disabled={datasetsQuery.isFetching}>
+            <Button
+              size="sm"
+              onClick={() => datasetsQuery.refetch()}
+              disabled={datasetsQuery.isFetching}
+            >
               Actualizar
             </Button>
           </div>
           {datasetsQuery.isLoading ? (
-            <div className="h-32 animate-pulse rounded-md border bg-muted" />
+            <div className="h-40 animate-pulse rounded-md border bg-muted" />
           ) : (
             <DataTable
-              data={datasetsQuery.data ?? []}
+              data={datasets}
               columns={columns}
               emptyMessage="No hay datasets registrados"
-              caption={`Total: ${datasetsQuery.data?.length ?? 0}`}
+              caption={`Total: ${datasets.length}`}
               getRowId={(row) => row.id}
             />
           )}
@@ -159,30 +375,43 @@ export default function DatasetsPage() {
         <div className="rounded-lg border p-4">
           <h2 className="text-lg font-semibold">Registrar dataset</h2>
           <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
-            {/* Par (ComboBox buscable) */}
             <div className="space-y-2">
               <label className="text-sm font-medium">Par</label>
               <ComboBox
-                options={(symbolsQuery.data ?? []).map(s => ({ label: s.symbol, value: s.symbol }))}
+                options={(symbolsQuery.data ?? []).map((symbol) => ({
+                  label: symbol.symbol,
+                  value: symbol.symbol,
+                }))}
                 value={formState.symbol}
-                onChange={(v) =>
-                  setFormState((s) => ({ ...s, symbol: v, startLocal: "", endLocal: "" }))
+                onChange={(value) =>
+                  setFormState((state) => ({
+                    ...state,
+                    symbol: value,
+                    startLocal: "",
+                    endLocal: "",
+                  }))
                 }
                 placeholder="Seleccioná un par"
                 inputPlaceholder="Buscar par (p. ej., BTC)"
                 disabled={symbolsQuery.isLoading}
               />
-              {errors.symbol && <p className="text-xs text-destructive">{errors.symbol}</p>}
+              {errors.symbol ? (
+                <p className="text-xs text-destructive">{errors.symbol}</p>
+              ) : null}
             </div>
 
-            {/* Interval (Select con fondo y scroll; la búsqueda tipiada básica la hace Radix) */}
             <div className="space-y-2">
               <label className="text-sm font-medium">Temporalidad</label>
               <Select
                 onOpenChange={setIntervalsOpen}
                 value={formState.interval}
-                onValueChange={(v: Interval) =>
-                  setFormState((s) => ({ ...s, interval: v, startLocal: "", endLocal: "" }))
+                onValueChange={(value: Interval) =>
+                  setFormState((state) => ({
+                    ...state,
+                    interval: value,
+                    startLocal: "",
+                    endLocal: "",
+                  }))
                 }
               >
                 <SelectTrigger>
@@ -190,25 +419,35 @@ export default function DatasetsPage() {
                 </SelectTrigger>
                 <SelectContent>
                   {intervalsQuery.isLoading ? (
-                    <div className="p-2 text-sm">Cargando...</div>
-                  ) : (intervalsQuery.data ?? []).map((i) => (
-                    <SelectItem key={i} value={i}>{i}</SelectItem>
+                    <div className="p-2 text-sm">Cargando…</div>
+                  ) : (
+                    intervalsQuery.data ?? []
+                  ).map((interval) => (
+                    <SelectItem key={interval} value={interval}>
+                      {interval}
+                    </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              {errors.interval && <p className="text-xs text-destructive">{errors.interval}</p>}
+              {errors.interval ? (
+                <p className="text-xs text-destructive">{errors.interval}</p>
+              ) : null}
             </div>
 
-            {/* Range */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <label className="text-sm font-medium">Desde</label>
                 <Input
                   type="datetime-local"
                   min={minLocal}
                   max={maxLocal}
-                  value={formState.startLocal || (minLocal ?? "")}
-                  onChange={(e) => setFormState((s) => ({ ...s, startLocal: e.target.value }))}
+                  value={formState.startLocal || minLocal || ""}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      startLocal: event.target.value,
+                    }))
+                  }
                   disabled={!r}
                 />
               </div>
@@ -218,33 +457,78 @@ export default function DatasetsPage() {
                   type="datetime-local"
                   min={minLocal}
                   max={maxLocal}
-                  value={formState.endLocal || (maxLocal ?? "")}
-                  onChange={(e) => setFormState((s) => ({ ...s, endLocal: e.target.value }))}
+                  value={formState.endLocal || maxLocal || ""}
+                  onChange={(event) =>
+                    setFormState((state) => ({
+                      ...state,
+                      endLocal: event.target.value,
+                    }))
+                  }
                   disabled={!r}
                 />
-                {(errors.startTime || errors.endTime) && (
+                {(errors.startTime || errors.endTime) ? (
                   <p className="text-xs text-destructive">
                     {errors.startTime || errors.endTime}
                   </p>
-                )}
-                {(!r && formState.symbol && formState.interval) && (
+                ) : null}
+                {!r && formState.symbol && formState.interval ? (
                   <p className="text-xs text-muted-foreground">
-                    Obteniendo rango disponible para {formState.symbol} {formState.interval}...
+                    Obteniendo rango disponible…
                   </p>
-                )}
+                ) : null}
               </div>
             </div>
 
             <Button
               type="submit"
               className="w-full"
-              disabled={createDataset.isPending || !formState.symbol || !formState.interval}
+              disabled={
+                createDataset.isPending ||
+                !formState.symbol ||
+                !formState.interval
+              }
             >
-              {createDataset.isPending ? "Guardando..." : "Registrar"}
+              {createDataset.isPending ? "Guardando…" : "Registrar"}
             </Button>
           </form>
         </div>
       </section>
+
+      <DatasetIngestDrawer
+        open={Boolean(selectedDatasetId)}
+        dataset={activeDataset ?? null}
+        detail={ingestState.data}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedDatasetId(null);
+          }
+        }}
+        onCancel={() => {
+          if (!selectedDatasetId) return;
+          cancelIngestMutation.mutate(selectedDatasetId);
+        }}
+        cancelDisabled={cancelIngestMutation.isPending}
+        isPolling={ingestState.isPolling}
+      />
+
+      <ConfirmDialog
+        open={Boolean(confirmDatasetDeletion)}
+        title={confirmState?.force ? "Eliminar durante la ingesta" : "Eliminar dataset"}
+        description={
+          confirmState?.force
+            ? "El dataset está en ingesta. Esto forzará su eliminación inmediata."
+            : "Esta acción eliminará el dataset de manera permanente."
+        }
+        confirmLabel={confirmState?.force ? "Force delete" : "Eliminar"}
+        onConfirm={() => {
+          if (!confirmState) return;
+          deleteMutation.mutate({
+            id: confirmState.dataset.id,
+            force: confirmState.force,
+          });
+        }}
+        onCancel={() => setConfirmState(null)}
+      />
     </div>
   );
 }

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "destructive";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirmar",
+  cancelLabel = "Cancelar",
+  variant = "destructive",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  if (!mounted || !open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-background/70 backdrop-blur" onClick={onCancel} />
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        className={cn(
+          "relative z-10 w-full max-w-md rounded-lg border bg-background p-6 shadow-xl",
+          "space-y-4"
+        )}
+      >
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold">{title}</h3>
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+          <Button variant={variant} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/DatasetIngestDrawer.tsx
+++ b/src/components/DatasetIngestDrawer.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import type { Dataset, DatasetDetail, DatasetStatus } from "@/types/datasets";
+
+interface DatasetIngestDrawerProps {
+  open: boolean;
+  dataset: Dataset | null;
+  detail: DatasetDetail | null;
+  onOpenChange: (open: boolean) => void;
+  onCancel: () => void;
+  cancelDisabled?: boolean;
+  isPolling?: boolean;
+}
+
+const STATUS_VARIANT: Record<DatasetStatus, "default" | "secondary" | "outline"> = {
+  Registered: "outline",
+  Ingesting: "secondary",
+  Ready: "default",
+  Failed: "outline",
+  Canceled: "outline",
+};
+
+const STATUS_CLASS: Partial<Record<DatasetStatus, string>> = {
+  Ready: "bg-emerald-100 text-emerald-900 border-emerald-200 dark:bg-emerald-500/20 dark:text-emerald-100",
+  Failed: "bg-destructive text-destructive-foreground border-destructive",
+  Canceled: "bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-500/20 dark:text-yellow-100",
+  Ingesting: "bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-500/20 dark:text-blue-100",
+};
+
+export function DatasetIngestDrawer({
+  open,
+  dataset,
+  detail,
+  onOpenChange,
+  onCancel,
+  cancelDisabled,
+  isPolling,
+}: DatasetIngestDrawerProps) {
+  const [mounted, setMounted] = useState(false);
+  const logsRef = useRef<HTMLPreElement | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  const merged = useMemo(() => {
+    if (!dataset && !detail) return null;
+    if (!dataset) return detail;
+    if (!detail) return dataset;
+    return { ...dataset, ...detail };
+  }, [dataset, detail]);
+
+  useEffect(() => {
+    if (!open) return;
+    const node = logsRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [detail?.logs, open]);
+
+  if (!mounted || !open || !merged) {
+    return null;
+  }
+
+  const progress = Math.round(merged.progress ?? 0);
+  const status = merged.status ?? "Registered";
+  const logs = detail?.logs ?? [];
+
+  const badgeVariant = STATUS_VARIANT[status] ?? "default";
+  const badgeClass = STATUS_CLASS[status];
+
+  return createPortal(
+    <div className="fixed inset-0 z-40 flex">
+      <div className="absolute inset-0 bg-background/70 backdrop-blur" onClick={() => onOpenChange(false)} />
+      <aside className="relative ml-auto flex h-full w-full max-w-3xl flex-col border-l bg-background shadow-xl">
+        <header className="flex items-start justify-between border-b p-6">
+          <div className="space-y-1">
+            <h2 className="text-xl font-semibold">
+              {merged.name ?? `${merged.symbol} ${merged.interval}`}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Última actualización: {merged.updatedAt ? new Date(merged.updatedAt).toLocaleString() : "-"}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant={badgeVariant} className={badgeClass}>{status}</Badge>
+            <Button variant="ghost" onClick={() => onOpenChange(false)}>
+              Cerrar
+            </Button>
+          </div>
+        </header>
+        <div className="flex flex-1 flex-col gap-6 overflow-y-auto p-6">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Progreso</span>
+              <span className="text-sm tabular-nums text-muted-foreground">{progress}%</span>
+            </div>
+            <Progress value={progress} className="h-3" />
+            {detail?.lastMessage ? (
+              <p className="text-sm text-muted-foreground">{detail.lastMessage}</p>
+            ) : null}
+            {isPolling ? (
+              <p className="text-xs text-muted-foreground">Reconectando…</p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium">Logs recientes</h3>
+              <span className="text-xs text-muted-foreground">Máximo 50 líneas</span>
+            </div>
+            <pre
+              ref={logsRef}
+              className="h-64 overflow-auto rounded-md border bg-muted/60 p-3 text-xs"
+            >
+              {logs.length === 0 ? "Sin eventos todavía" : logs.slice(-50).join("\n")}
+            </pre>
+          </div>
+        </div>
+        {status === "Ingesting" ? (
+          <footer className="flex items-center justify-end gap-2 border-t p-6">
+            <Button variant="destructive" onClick={onCancel} disabled={cancelDisabled}>
+              Cancelar ingesta
+            </Button>
+          </footer>
+        ) : null}
+      </aside>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ProgressProps extends React.ComponentProps<"div"> {
+  value?: number;
+  max?: number;
+}
+
+export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, max = 100, ...props }, ref) => {
+    const clamped = Math.max(0, Math.min(value, max));
+    const percentage = (clamped / max) * 100;
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "relative h-2 w-full overflow-hidden rounded-full bg-muted",
+          className
+        )}
+        role="progressbar"
+        aria-valuenow={Number.isFinite(percentage) ? Math.round(percentage) : undefined}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        {...props}
+      >
+        <div
+          className="h-full w-full flex-1 bg-primary transition-all"
+          style={{ transform: `translateX(-${100 - percentage}%)` }}
+        />
+      </div>
+    );
+  }
+);
+Progress.displayName = "Progress";

--- a/src/hooks/useDatasetIngest.ts
+++ b/src/hooks/useDatasetIngest.ts
@@ -1,0 +1,258 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { cancelIngest, getDataset, ingestEvents } from "@/api/datasets";
+import type { DatasetDetail, DatasetStatus, IngestEvent } from "@/types/datasets";
+
+const POLLING_INTERVAL = 2000;
+const FINAL_STATUSES: DatasetStatus[] = ["Ready", "Failed", "Canceled"];
+
+function isFinalStatus(status: DatasetStatus | undefined): status is DatasetStatus {
+  return status !== undefined && FINAL_STATUSES.includes(status);
+}
+
+interface UseDatasetIngestOptions {
+  enabled?: boolean;
+}
+
+interface UseDatasetIngestResult {
+  data: DatasetDetail | null;
+  isLoading: boolean;
+  error: Error | null;
+  isPolling: boolean;
+  cancel: () => Promise<void>;
+  refetch: () => Promise<void>;
+  lastEvent?: IngestEvent["type"];
+}
+
+export function useDatasetIngest(
+  id: string,
+  options: UseDatasetIngestOptions = {}
+): UseDatasetIngestResult {
+  const enabled = Boolean(id) && (options.enabled ?? true);
+  const [data, setData] = useState<DatasetDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+  const lastEventRef = useRef<IngestEvent["type"] | undefined>();
+  const pollingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const statusRef = useRef<DatasetStatus | undefined>();
+
+  useEffect(() => {
+    statusRef.current = data?.status;
+  }, [data?.status]);
+
+  const stopPolling = useCallback(() => {
+    if (pollingTimerRef.current) {
+      clearInterval(pollingTimerRef.current);
+      pollingTimerRef.current = null;
+    }
+    setIsPolling(false);
+  }, []);
+
+  const stopEventSource = useCallback(() => {
+    const es = eventSourceRef.current;
+    if (es) {
+      es.close();
+      eventSourceRef.current = null;
+    }
+  }, []);
+
+  const applyPatch = useCallback((patch: Partial<DatasetDetail>, appendLog?: string) => {
+    setData((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      let logs = prev.logs ?? [];
+      if (patch.logs) {
+        logs = patch.logs.slice(-200);
+      }
+      if (appendLog) {
+        logs = [...logs, appendLog].slice(-200);
+      }
+
+      return {
+        ...prev,
+        ...patch,
+        logs,
+        lastMessage: patch.lastMessage ?? prev.lastMessage,
+        updatedAt: patch.updatedAt ?? prev.updatedAt,
+        progress: patch.progress ?? prev.progress ?? 0,
+        status: patch.status ?? prev.status,
+      };
+    });
+  }, []);
+
+  const fetchDetail = useCallback(
+    async (showLoading: boolean) => {
+      if (!enabled) return;
+      if (showLoading) {
+        setIsLoading(true);
+      }
+      try {
+        const detail = await getDataset(id);
+        setData((prev) => {
+          const logs = (detail.logs ?? prev?.logs ?? []).slice(-200);
+          return {
+            ...detail,
+            progress: detail.progress ?? prev?.progress ?? 0,
+            lastMessage: detail.lastMessage ?? prev?.lastMessage,
+            logs,
+          };
+        });
+        setError(null);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err);
+        } else {
+          setError(new Error("No se pudo obtener el estado del dataset"));
+        }
+      } finally {
+        if (showLoading) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [enabled, id]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      stopEventSource();
+      stopPolling();
+      setData(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const startPolling = () => {
+      if (cancelled) return;
+      stopEventSource();
+      if (pollingTimerRef.current) return;
+      setIsPolling(true);
+      pollingTimerRef.current = setInterval(() => {
+        fetchDetail(false);
+      }, POLLING_INTERVAL);
+    };
+
+    const handleEvent = (event: MessageEvent, explicitType?: IngestEvent["type"]) => {
+      try {
+        const payload = JSON.parse(event.data) as Partial<IngestEvent>;
+        const type = (explicitType ?? payload.type) as IngestEvent["type"];
+        if (!type) return;
+
+        lastEventRef.current = type;
+
+        switch (type) {
+          case "status":
+            applyPatch({
+              status: payload.status as DatasetStatus,
+              updatedAt: payload.updatedAt as number,
+            });
+            break;
+          case "progress":
+            applyPatch({
+              progress: payload.progress as number,
+              lastMessage: payload.lastMessage,
+              updatedAt: payload.updatedAt as number,
+            });
+            break;
+          case "log": {
+            const line = payload.line as string;
+            if (line) {
+              const ts = payload.ts as number | undefined;
+              const formatted = ts
+                ? `[${new Date(ts).toLocaleTimeString()}] ${line}`
+                : line;
+              applyPatch({}, formatted);
+            }
+            break;
+          }
+          case "done":
+            applyPatch({
+              status: payload.status as DatasetStatus,
+              updatedAt: payload.updatedAt as number,
+              progress: 100,
+            });
+            stopEventSource();
+            stopPolling();
+            break;
+          case "error":
+            applyPatch({
+              status: payload.status as DatasetStatus,
+              updatedAt: payload.updatedAt as number,
+              lastMessage: payload.lastMessage,
+            });
+            stopEventSource();
+            stopPolling();
+            break;
+          default:
+            break;
+        }
+      } catch (err) {
+        console.error("Failed to parse ingest event", err);
+      }
+    };
+
+    const attachEventSource = () => {
+      const es = ingestEvents(id);
+      eventSourceRef.current = es;
+
+      es.addEventListener("status", (event) => handleEvent(event as MessageEvent, "status"));
+      es.addEventListener("progress", (event) => handleEvent(event as MessageEvent, "progress"));
+      es.addEventListener("log", (event) => handleEvent(event as MessageEvent, "log"));
+      es.addEventListener("done", (event) => handleEvent(event as MessageEvent, "done"));
+      es.addEventListener("error", (event) => handleEvent(event as MessageEvent, "error"));
+
+      es.onmessage = (event) => handleEvent(event as MessageEvent);
+
+      es.onerror = () => {
+        if (cancelled) return;
+        stopEventSource();
+        if (!isFinalStatus(statusRef.current)) {
+          startPolling();
+        }
+      };
+    };
+
+    fetchDetail(true).finally(() => {
+      if (cancelled) return;
+      attachEventSource();
+    });
+
+    return () => {
+      cancelled = true;
+      stopEventSource();
+      stopPolling();
+    };
+  }, [applyPatch, enabled, fetchDetail, id, stopEventSource, stopPolling]);
+
+  const cancel = useCallback(async () => {
+    if (!enabled) return;
+    await cancelIngest(id);
+    await fetchDetail(true);
+  }, [enabled, fetchDetail, id]);
+
+  const refetch = useCallback(async () => {
+    await fetchDetail(true);
+  }, [fetchDetail]);
+
+  return useMemo(
+    () => ({
+      data,
+      isLoading,
+      error,
+      isPolling,
+      cancel,
+      refetch,
+      lastEvent: lastEventRef.current,
+    }),
+    [cancel, data, error, isLoading, isPolling, refetch]
+  );
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -22,3 +22,30 @@ export function formatNumber(value: string | number, fractionDigits = 2) {
 export function formatDateTime(ms: number) {
   return new Date(ms).toLocaleString();
 }
+
+const RELATIVE_UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
+  { unit: "year", ms: 1000 * 60 * 60 * 24 * 365 },
+  { unit: "month", ms: 1000 * 60 * 60 * 24 * 30 },
+  { unit: "week", ms: 1000 * 60 * 60 * 24 * 7 },
+  { unit: "day", ms: 1000 * 60 * 60 * 24 },
+  { unit: "hour", ms: 1000 * 60 * 60 },
+  { unit: "minute", ms: 1000 * 60 },
+  { unit: "second", ms: 1000 },
+];
+
+const rtf = new Intl.RelativeTimeFormat("es", { numeric: "auto" });
+
+export function formatRelativeTime(ms?: number | null) {
+  if (!ms) return "-";
+  const diff = ms - Date.now();
+  const absDiff = Math.abs(diff);
+
+  for (const { unit, ms: unitMs } of RELATIVE_UNITS) {
+    if (absDiff >= unitMs || unit === "second") {
+      const value = Math.round(diff / unitMs);
+      return rtf.format(value, unit);
+    }
+  }
+
+  return "-";
+}

--- a/src/types/datasets.ts
+++ b/src/types/datasets.ts
@@ -1,0 +1,32 @@
+export type DatasetStatus =
+  | "Registered"
+  | "Ingesting"
+  | "Ready"
+  | "Failed"
+  | "Canceled";
+
+export interface Dataset {
+  id: string;
+  name?: string;
+  symbol: string;
+  interval: string;
+  status: DatasetStatus;
+  createdAt: number;
+  updatedAt?: number;
+  progress?: number;
+  lastMessage?: string;
+}
+
+export interface DatasetDetail extends Dataset {
+  progress: number;
+  lastMessage?: string;
+  updatedAt: number;
+  logs?: string[];
+}
+
+export type IngestEvent =
+  | { type: "status"; status: DatasetStatus; updatedAt: number }
+  | { type: "progress"; progress: number; lastMessage?: string; updatedAt: number }
+  | { type: "log"; line: string; ts: number }
+  | { type: "done"; status: DatasetStatus; updatedAt: number }
+  | { type: "error"; status: DatasetStatus; lastMessage: string; updatedAt: number };


### PR DESCRIPTION
## Summary
- add dataset API client and domain types for ingest progress
- implement SSE-based useDatasetIngest hook plus drawer/confirm/progress UI components
- overhaul datasets page to surface live progress, actions, and relative timestamps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d608cd1998832b9daf953012d247c1